### PR TITLE
Fix dataset extraction when ➡️ `prefix` is passed to `download_extract_sqlite`  | installed an additional version of the dataset

### DIFF
--- a/src/chembl_downloader/api.py
+++ b/src/chembl_downloader/api.py
@@ -256,8 +256,10 @@ def download_extract_sqlite(
     # Extraction will be done in the same directory as the download.
     # All ChEMBL SQLite dumps have the same internal folder structure,
     # so assume there's going to be a directory here
-    directory = path.parent.joinpath("data")
-    if directory.is_dir():
+    directory = path.parent.joinpath("data").mkdir(exist_ok=True)
+    
+    rv = _find_sqlite_file(directory)
+    if rv is None:
         logger.info("unarchiving %s to %s", path, directory)
         with tarfile.open(path, mode="r", encoding="utf-8") as tar_file:
             tar_file.extractall(directory)  # noqa:S202

--- a/src/chembl_downloader/api.py
+++ b/src/chembl_downloader/api.py
@@ -257,7 +257,7 @@ def download_extract_sqlite(
     # All ChEMBL SQLite dumps have the same internal folder structure,
     # so assume there's going to be a directory here
     directory = path.parent.joinpath("data")
-    if not directory.is_dir():
+    if directory.is_dir():
         logger.info("unarchiving %s to %s", path, directory)
         with tarfile.open(path, mode="r", encoding="utf-8") as tar_file:
             tar_file.extractall(directory)  # noqa:S202


### PR DESCRIPTION
Hi Charles, thanks for the nice package!

I noticed I couldn't use a custom `prefix` when downloading the data, which got me the error:

`FileNotFoundError: could not find a .db file in the ChEMBL archive`

What I observed is that some cases (e.g.; when you pass the prefix) the `data/` directory was created before the `if not directory.is_dir():` statement.

Downloading and extracting for the first time didn't cause any issues. However, I thought a user (me) could also want to have different versions of testing, like `chembl/35/` and `chembl/34/`. This second download also caused `data/` to be automatically created, preventing extraction.

This PR should fix it. Let me know if there's other adjustment I would need to make.

<!--
Thanks for contributing to `chembl-downloader`.
To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?

Caution: the maintainers often take an active role in pull requests,
and may push to your branch. Therefore, you should always sync your
local copy of the repository with the remote before 
work.
-->

## Summary

Sometimes the extraction would fail immediately after download because of the `data/` directory creation prior to `if not directory.is_dir():` statement.

<!-- What's the purpose of the change? What does it do, and why? -->
