### PR TITLE
Improve handling of versions

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,10 +4,28 @@ import unittest
 from textwrap import dedent
 
 import chembl_downloader
+from chembl_downloader.api import _clean_version
 
 
 class TestApi(unittest.TestCase):
     """Tests for the API."""
+
+    def test_clean_version(self) -> None:
+        """Test cleaning the version."""
+        for input_version, (expected_version, expected_fmt_version) in [
+            # single digit
+            ("1", ("01", "1")),
+            (1, ("01", "1")),
+            # double-digit
+            ("35", ("35", "35")),
+            (35, ("35", "35")),
+            # point
+            ("22.1", ("22_1", "22.1")),
+        ]:
+            with self.subTest():
+                fmt_version, version = _clean_version(input_version)
+                self.assertEqual(expected_fmt_version, fmt_version, msg="incorrect format version")
+                self.assertEqual(expected_version, version, msg="incorrect normalized version")
 
     def test_latest_version(self) -> None:
         """Test getting the latest version."""


### PR DESCRIPTION
This was motivated by #21, where it was annoying to do `str(version)` when looping through versions. Now, functions in `chembl-downloader` will also accept integer versions.

This also makes some more careful testing of the way that versions are normalized, especially for versions before v10 and the two instances of versions that have a minor (i.e., v22.1 and v24.1)