### PR TITLE
Enable passing version info

### DIFF
--- a/src/chembl_downloader/api.py
+++ b/src/chembl_downloader/api.py
@@ -180,7 +180,7 @@ def _download_helper(
 
 
 def _get_version_info(version: VersionHint | None, prefix: Sequence[str] | None) -> VersionInfo:
-    if isinstance(version, VersionHint):
+    if isinstance(version, VersionInfo):
         return version
 
     flavor = _ensure_version_helper(version)


### PR DESCRIPTION
As a follow-up to #22, this allows for passing pre-constructed version info objects